### PR TITLE
Handle missing permissions and connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ Work in progress. The extension lives in the `penpot-extension/` directory.
 
 ## Development
 Clone the repo and install dependencies with `npm install`. Load the extension
-in Chrome using the `penpot-extension/` folder.
+in Chrome using the `penpot-extension/` folder. When testing the popup, make
+sure the active tab is a normal webpage (not a Chrome Web Store or
+`chrome://` page) so that the content script can receive messages.

--- a/penpot-extension/manifest.json
+++ b/penpot-extension/manifest.json
@@ -3,6 +3,7 @@
   "name": "Penpot Exporter",
   "version": "0.1.0",
   "description": "Export designs directly to Penpot from Chrome.",
+  "permissions": ["tabs"],
   "action": {
     "default_popup": "popup.html"
   },

--- a/penpot-extension/popup.js
+++ b/penpot-extension/popup.js
@@ -4,7 +4,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   exportButton.addEventListener('click', () => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      chrome.tabs.sendMessage(tabs[0].id, { action: 'export' });
+      chrome.tabs.sendMessage(tabs[0].id, { action: 'export' }, () => {
+        if (chrome.runtime.lastError) {
+          console.error('Error sending message:', chrome.runtime.lastError);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- grant tabs permission to allow `chrome.tabs.query`
- log message send failures in the popup
- note that testing must happen on normal web pages in the README

## Testing
- `node -e "console.log('Node works');"`